### PR TITLE
Group address and value into item

### DIFF
--- a/merkle_drop/airdrop.py
+++ b/merkle_drop/airdrop.py
@@ -1,0 +1,9 @@
+from typing import Dict, List
+
+from .merkle_tree import Item
+
+AirdropData = Dict[bytes, int]
+
+
+def to_items(airdrop_data: AirdropData) -> List[Item]:
+    return [Item(address, value) for address, value in airdrop_data.items()]

--- a/merkle_drop/cli.py
+++ b/merkle_drop/cli.py
@@ -2,7 +2,8 @@ import click
 
 from eth_utils import encode_hex
 
-from .load_csv import load_airdrop_dict
+from merkle_drop.airdrop import to_items
+from .load_csv import load_airdrop_file
 from .merkle_tree import compute_merkle_root
 
 
@@ -12,10 +13,10 @@ def main():
 
 
 @main.command(short_help="Compute Merkle root")
-@click.argument("airdrop_json_file")
-def root(airdrop_json_file):
+@click.argument("airdrop_file_name")
+def root(airdrop_file_name):
 
-    airdrop_dict = load_airdrop_dict(airdrop_json_file)  # noqa F841
-    merkle_root = compute_merkle_root(airdrop_dict)
+    airdrop_data = load_airdrop_file(airdrop_file_name)
+    merkle_root = compute_merkle_root(to_items(airdrop_data))
 
     click.echo(f"The merkle root is: {encode_hex(merkle_root)}")

--- a/merkle_drop/load_csv.py
+++ b/merkle_drop/load_csv.py
@@ -1,8 +1,9 @@
+from typing import Dict
 import csv
 from eth_utils import is_checksum_address, to_canonical_address
 
 
-def load_airdrop_dict(airdrop_file: str):
+def load_airdrop_file(airdrop_file: str) -> Dict[bytes, int]:
     with open(airdrop_file) as file:
         reader = csv.reader(file)
         address_value_pairs = list(reader)

--- a/merkle_drop/load_json.py
+++ b/merkle_drop/load_json.py
@@ -1,9 +1,0 @@
-import json
-
-
-def load_airdrop_dict(airdrop_file: str):
-
-    with open(airdrop_file) as file:
-        airdrop_dict = json.load(file)
-
-    return airdrop_dict

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 
 from eth_utils import to_checksum_address, to_normalized_address
 
-from merkle_drop.load_csv import load_airdrop_dict, validate_address_value_pairs
+from merkle_drop.load_csv import load_airdrop_file, validate_address_value_pairs
 from merkle_drop.cli import main
 
 
@@ -11,19 +11,19 @@ A_ADDRESS = b"\xaa" * 20
 B_ADDRESS = b"\xbb" * 20
 
 
-AIRDROP_DICT = {A_ADDRESS: 10, B_ADDRESS: 20}
+AIRDROP_DATA = {A_ADDRESS: 10, B_ADDRESS: 20}
 
 
 @pytest.fixture()
 def airdrop_list_file(tmp_path):
     folder = tmp_path / "subfolder"
     folder.mkdir()
-    file_path = folder / "airdrop_list.json"
+    file_path = folder / "airdrop_list.csv"
     file_path.write_text(
         "\n".join(
             (
                 ",".join((to_checksum_address(address), str(value)))
-                for address, value in AIRDROP_DICT.items()
+                for address, value in AIRDROP_DATA.items()
             )
         )
     )
@@ -41,10 +41,10 @@ def test_merkle_root_cli(runner, airdrop_list_file):
     assert result.exit_code == 0
 
 
-def test_read_json_file(airdrop_list_file):
+def test_read_csv_file(airdrop_list_file):
 
-    data = load_airdrop_dict(airdrop_list_file)
-    assert data == AIRDROP_DICT
+    data = load_airdrop_file(airdrop_list_file)
+    assert data == AIRDROP_DATA
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This groups the address and value into an item.
The idea is that most part of the merkle tree is independend of the
structure of the items in the leaves, so they should just operate on an
item. The only part where the structure matters is when calculating the
leave hashes. This should also make it simple to switch the format if it
changes.