### PR TITLE
Simplify burnUnusableTokens

### DIFF
--- a/contracts/contracts/DroppedToken.sol
+++ b/contracts/contracts/DroppedToken.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.8;
 
 import "./SafeMath.sol";
+import "./MerkleDrop.sol";
 
 
 // This token is a copy of the TrustlinesNetworkToken as of commit 0651fb21bc35380a551988a8dc9fedd763abb253.
@@ -16,6 +17,9 @@ contract DroppedToken {
     string private _symbol;
     uint8 private _decimals;
     uint256 private _totalSupply;
+    bool private burnLoopFlag;
+
+    MerkleDrop public merkleDrop;
 
     mapping (address => uint256) private _balances;
     mapping (address => mapping (address => uint256)) private _allowances;
@@ -29,6 +33,10 @@ contract DroppedToken {
         _decimals = decimals;
 
         _mint(preMintAddress, preMintAmount);
+    }
+
+    function storeAddressOfMerkleDrop(address _merkleDrop) public {
+        merkleDrop = MerkleDrop(_merkleDrop);
     }
 
     function balanceOf(address account) public view returns (uint256) {
@@ -56,6 +64,7 @@ contract DroppedToken {
     }
 
     function transfer(address recipient, uint256 amount) public returns (bool) {
+        merkleDrop.burnUnusableTokens();
         _transfer(msg.sender, recipient, amount);
     }
 
@@ -75,6 +84,10 @@ contract DroppedToken {
     }
 
     function burn(uint256 amount) public {
+        if (! burnLoopFlag) {
+            burnLoopFlag = true;
+            merkleDrop.burnUnusableTokens();
+        }
         _burn(msg.sender, amount);
     }
 

--- a/contracts/contracts/MerkleDrop.sol
+++ b/contracts/contracts/MerkleDrop.sol
@@ -37,6 +37,16 @@ contract MerkleDrop {
         require(valueToSend != 0, "The decayed entitled value is now null.");
 
         withdrawn[recipient] = true;
+
+        // we burn the value not sent that has not been burnt via burnUnusableTokens yet.
+        uint valueToBurn;
+        if (lastBurnTime == 0) {
+            valueToBurn = value - valueToSend;
+        } else {
+            valueToBurn = value * (now - lastBurnTime)/decayDurationInSeconds;
+        }
+        burn(valueToBurn);
+
         droppedToken.transfer(recipient, valueToSend);
         emit Withdraw(recipient, value);
     }

--- a/contracts/contracts/MerkleDrop.sol
+++ b/contracts/contracts/MerkleDrop.sol
@@ -37,7 +37,6 @@ contract MerkleDrop {
         require(valueToSend != 0, "The decayed entitled value is now null.");
 
         withdrawn[recipient] = true;
-        burn(value - valueToSend);
         droppedToken.transfer(recipient, valueToSend);
         emit Withdraw(recipient, value);
     }
@@ -63,16 +62,21 @@ contract MerkleDrop {
     }
 
     function burnUnusableTokens() public {
-        require(now >= decayStartTime, "The decay star time has not been reached yet, there is no token to burn.");
+        require(now >= decayStartTime, "The decay start time has not been reached yet, there is no token to burn.");
+        uint decayEndTime = decayStartTime + decayDurationInSeconds;
+        uint remainingDecayTime;
         uint timeToBurn;
         if (lastBurnTime == 0) {
             // We have never burned yet
+            remainingDecayTime = decayDurationInSeconds;
             timeToBurn = now - decayStartTime;
         } else {
+            remainingDecayTime = decayEndTime - lastBurnTime;
             timeToBurn = now - lastBurnTime;
         }
         uint totalEntitlement = droppedToken.balanceOf(address(this));
-        uint totalDecay = decayOverPeriod(totalEntitlement, timeToBurn);
+
+        uint totalDecay = totalEntitlement*(timeToBurn)/(remainingDecayTime);
 
         lastBurnTime = now;
         burn(totalDecay);

--- a/contracts/contracts/MerkleDrop.sol
+++ b/contracts/contracts/MerkleDrop.sol
@@ -11,17 +11,17 @@ contract MerkleDrop {
     uint public decayDurationInSeconds;
     uint public lastBurnTime;
 
-    uint public initialEntitlement = 15000000;  // just for testing, need to be set in the constructor
-    uint public withdrawnValue;  // The total not decayed withdrawn entitlements
-    uint public burntTokens;  // the total burnt tokens
+    uint public initialEntitlement;
+    uint public withdrawnValue;  // The total not decayed withdrawn initial entitlements
 
     mapping (address => bool) withdrawn;
 
     event Withdraw(address recipient, uint value);
     event Burn(uint value);
 
-    constructor(DroppedToken _droppedToken, bytes32 _root, uint _decayStartTime, uint _decayDurationInSeconds) public {
+    constructor(DroppedToken _droppedToken, uint _initialEntitlement, bytes32 _root, uint _decayStartTime, uint _decayDurationInSeconds) public {
         droppedToken = _droppedToken;
+        initialEntitlement = _initialEntitlement;
         root = _root;
         decayStartTime = _decayStartTime;
         decayDurationInSeconds = _decayDurationInSeconds;
@@ -85,8 +85,6 @@ contract MerkleDrop {
         // resulting in burning tokens based on the wrong balance, thus burning too many tokens.
         uint currentBalance = droppedToken.balanceOf(address(this)) - valueToWithdraw;
         uint toBurn = currentBalance - decayedRemainingValue;
-
-        burntTokens += toBurn;
 
         burn(toBurn);
         return;

--- a/contracts/contracts/MerkleDrop.sol
+++ b/contracts/contracts/MerkleDrop.sol
@@ -67,6 +67,12 @@ contract MerkleDrop {
         uint remainingDecayTime;
         uint timeToBurn;
 
+        if (now >= decayEndTime) {
+            lastBurnTime = now;
+            burn(droppedToken.balanceOf(address(this)));
+            return;
+        }
+
         if (lastBurnTime == 0) {
             // We have never burned yet
             remainingDecayTime = decayDurationInSeconds;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,7 @@ def merkle_drop_contract(
         "MerkleDrop",
         constructor_args=(
             dropped_token_contract.address,
+            premint_token_value,
             root_hash_for_tree_data,
             decay_start_time,
             decay_duration,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def premint_token_owner(accounts):
 
 @pytest.fixture(scope="session")
 def premint_token_value():
-    # The returned value should be higher than the dropped value: see values in `tree_data`
+    # The returned value should be equal to the dropped value: see values in `tree_data`
     return 15_000_000
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,10 @@ def merkle_drop_contract(
         ),
     )
 
+    dropped_token_contract.functions.storeAddressOfMerkleDrop(
+        contract.address
+    ).transact()
+
     dropped_token_contract.functions.transfer(
         contract.address, premint_token_value
     ).transact({"from": premint_token_owner})

--- a/tests/test_merkle_drop.py
+++ b/tests/test_merkle_drop.py
@@ -325,12 +325,24 @@ def test_everyone_can_withdraw_after_burns(
     time_travel_chain_to_decay_multiplier(decay_multiplier)
     merkle_drop_contract.functions.burnUnusableTokens().transact()
 
+    print(
+        dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
+        / 1000
+    )
+
     for i in range(1, len(proofs_for_tree_data)):
         address = tree_data[i].address
         value = tree_data[i].value
         proof = proofs_for_tree_data[i]
 
         merkle_drop_contract.functions.withdrawFor(address, value, proof).transact()
+
+        print(
+            dropped_token_contract.functions.balanceOf(
+                merkle_drop_contract.address
+            ).call()
+            / 1000
+        )
 
     decay_multiplier = 1
     time_travel_chain_to_decay_multiplier(decay_multiplier)

--- a/tests/test_merkle_drop.py
+++ b/tests/test_merkle_drop.py
@@ -298,17 +298,12 @@ def test_everyone_can_withdraw_after_burns(
     proofs_for_tree_data,
     time_travel_chain_to_decay_multiplier,
 ):
-    # Test scenario with burn at two different times and a withdraw
+    # Test scenario with burn at two different times and withdraws
     # to see if every entitled user is able to withdraw and the final balance is 0
 
     decay_multiplier = 0.25
     time_travel_chain_to_decay_multiplier(decay_multiplier)
     merkle_drop_contract.functions.burnUnusableTokens().transact()
-
-    print(
-        dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
-        / 1000
-    )
 
     decay_multiplier = 0.5
     time_travel_chain_to_decay_multiplier(decay_multiplier)
@@ -316,19 +311,9 @@ def test_everyone_can_withdraw_after_burns(
         eligible_address_0, eligible_value_0, proof_0
     ).transact()
 
-    print(
-        dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
-        / 1000
-    )
-
     decay_multiplier = 0.75
     time_travel_chain_to_decay_multiplier(decay_multiplier)
     merkle_drop_contract.functions.burnUnusableTokens().transact()
-
-    print(
-        dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
-        / 1000
-    )
 
     for i in range(1, len(proofs_for_tree_data)):
         address = tree_data[i].address
@@ -336,13 +321,6 @@ def test_everyone_can_withdraw_after_burns(
         proof = proofs_for_tree_data[i]
 
         merkle_drop_contract.functions.withdrawFor(address, value, proof).transact()
-
-        print(
-            dropped_token_contract.functions.balanceOf(
-                merkle_drop_contract.address
-            ).call()
-            / 1000
-        )
 
     decay_multiplier = 1
     time_travel_chain_to_decay_multiplier(decay_multiplier)

--- a/tests/test_merkle_drop.py
+++ b/tests/test_merkle_drop.py
@@ -330,3 +330,28 @@ def test_everyone_can_withdraw_after_burns(
         dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
         == 0
     )
+
+
+def test_burn_enough_token(
+    merkle_drop_contract,
+    dropped_token_contract,
+    eligible_address_0,
+    eligible_value_0,
+    proof_0,
+    time_travel_chain_to_decay_multiplier,
+    premint_token_value,
+):
+    # test whether the value of token we burn is the maximum value we can burn.
+
+    decay_multiplier = 0.5
+    time_travel_chain_to_decay_multiplier(decay_multiplier)
+    merkle_drop_contract.functions.withdrawFor(
+        eligible_address_0, eligible_value_0, proof_0
+    ).transact()
+
+    merkle_drop_contract.functions.burnUnusableTokens().transact()
+
+    assert (
+        dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
+        == (premint_token_value - eligible_value_0) * 0.5
+    )

--- a/tests/test_merkle_drop.py
+++ b/tests/test_merkle_drop.py
@@ -217,6 +217,20 @@ def test_burn_unusable_tokens(
     assert balance_after == (1 - decay_multiplier) * balance_before
 
 
+def test_burn_tokens_after_decay_duration(
+    merkle_drop_contract, dropped_token_contract, time_travel_chain_to_decay_multiplier
+):
+    decay_multiplier = 2
+    time_travel_chain_to_decay_multiplier(decay_multiplier)
+
+    merkle_drop_contract.functions.burnUnusableTokens().transact()
+    balance = dropped_token_contract.functions.balanceOf(
+        merkle_drop_contract.address
+    ).call()
+
+    assert balance == 0
+
+
 @pytest.mark.parametrize("decay_multiplier", [0, 0.25, 0.5, 0.75])
 def test_withdraw_after_burn(
     merkle_drop_contract,

--- a/tests/test_merkle_drop.py
+++ b/tests/test_merkle_drop.py
@@ -305,11 +305,21 @@ def test_everyone_can_withdraw_after_burns(
     time_travel_chain_to_decay_multiplier(decay_multiplier)
     merkle_drop_contract.functions.burnUnusableTokens().transact()
 
+    print(
+        dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
+        / 1000
+    )
+
     decay_multiplier = 0.5
     time_travel_chain_to_decay_multiplier(decay_multiplier)
     merkle_drop_contract.functions.withdrawFor(
         eligible_address_0, eligible_value_0, proof_0
     ).transact()
+
+    print(
+        dropped_token_contract.functions.balanceOf(merkle_drop_contract.address).call()
+        / 1000
+    )
 
     decay_multiplier = 0.75
     time_travel_chain_to_decay_multiplier(decay_multiplier)

--- a/tests/test_merkle_drop.py
+++ b/tests/test_merkle_drop.py
@@ -152,17 +152,13 @@ def test_entitlement_with_decay(
 def test_withdraw_with_decay(
     merkle_drop_contract,
     dropped_token_contract,
-    chain,
-    decay_start_time,
-    decay_duration,
+    time_travel_chain_to_decay_multiplier,
     decay_multiplier,
     eligible_address_0,
     eligible_value_0,
     proof_0,
 ):
-    time = int(decay_start_time + decay_duration * decay_multiplier)
-    chain.time_travel(time)
-    chain.mine_block()
+    time_travel_chain_to_decay_multiplier(decay_multiplier)
 
     merkle_drop_contract.functions.withdrawFor(
         eligible_address_0, eligible_value_0, proof_0
@@ -186,18 +182,14 @@ def test_entitlement_after_decay(
 
 def test_withdraw_after_decay(
     merkle_drop_contract,
-    chain,
-    decay_start_time,
-    decay_duration,
+    time_travel_chain_to_decay_multiplier,
     eligible_address_0,
     eligible_value_0,
     proof_0,
 ):
 
     decay_multiplier = 2
-    time = int(decay_start_time + decay_duration * decay_multiplier)
-    chain.time_travel(time)
-    chain.mine_block()
+    time_travel_chain_to_decay_multiplier(decay_multiplier)
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
         merkle_drop_contract.functions.withdrawFor(
@@ -209,15 +201,10 @@ def test_withdraw_after_decay(
 def test_burn_unusable_tokens(
     merkle_drop_contract,
     dropped_token_contract,
-    chain,
-    decay_start_time,
-    decay_duration,
+    time_travel_chain_to_decay_multiplier,
     decay_multiplier,
 ):
-
-    time = int(decay_start_time + decay_duration * decay_multiplier)
-    chain.time_travel(time)
-    chain.mine_block()
+    time_travel_chain_to_decay_multiplier(decay_multiplier)
 
     balance_before = dropped_token_contract.functions.balanceOf(
         merkle_drop_contract.address


### PR DESCRIPTION
We keep track of the tokens we already have burned and compare that to
the number of tokens that should have been burned at a given time. We
then burn the difference.