### PR TITLE
Contract can self-destruct after no tokens can be withdrawn

### DIFF
--- a/contracts/contracts/MerkleDrop.sol
+++ b/contracts/contracts/MerkleDrop.sol
@@ -14,7 +14,7 @@ contract MerkleDrop {
     uint public remainingValue;  // The total not decayed not withdrawn entitlements
     uint public spentTokens;  // The total tokens spent by the contract, burnt or withdrawn
 
-    mapping (address => bool) withdrawn;
+    mapping (address => bool) public withdrawn;
 
     event Withdraw(address recipient, uint value);
     event Burn(uint value);
@@ -86,6 +86,13 @@ contract MerkleDrop {
 
         spentTokens += toBurn;
         burn(toBurn);
+    }
+
+    function deleteContract() public {
+        require(now >= decayStartTime + decayDurationInSeconds, "The storage cannot be deleted before the end of the merkle drop.");
+        burnUnusableTokens();
+
+        selfdestruct(address(0));
     }
 
     function verifyProof(bytes32 leaf, bytes32[] memory proof) internal view returns (bool) {


### PR DESCRIPTION
closes https://github.com/trustlines-protocol/merkle-drop/issues/24

I would have liked cleaning the storage without destructing the contract not to mutate the code. However, to delete a mapping you need to delete each value independently, which is only possible if you stored all the keys before. So we would need to store the addresses that withdrawn in an array `address[]` which would make every withdraw more expensive by 20k gas.

I don't believe it is worth it, so I use `selfdestruct()` instead.