### PR TITLE
Add support for setting a CORS header

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ max_requests = 1000
 
 def on_starting(server):
     merkle_drop.server.init_gunicorn_logging()
+    merkle_drop.server.init_cors(origins="*")
     merkle_drop.server.init(
         airdrop_filename, decay_start_time, decay_duration_in_seconds
     )

--- a/constraints.txt
+++ b/constraints.txt
@@ -29,6 +29,8 @@ eth-utils==1.6.0
 ethpm==0.1.4a19
 flake8==3.7.7
 flake8-polyfill==1.0.2
+Flask==1.1.1
+Flask-Cors==3.0.8
 gunicorn==19.9.0
 hexbytes==0.2.0
 identify==1.4.3
@@ -36,8 +38,11 @@ idna==2.8
 importlib-metadata==0.17
 importlib-resources==1.0.2
 ipfshttpclient==0.4.12
+itsdangerous==1.1.0
+Jinja2==2.10.1
 jsonschema==2.6.0
 lru-dict==1.1.6
+MarkupSafe==1.1.1
 mccabe==0.6.1
 more-itertools==7.0.0
 multiaddr==0.0.8
@@ -88,5 +93,6 @@ virtualenv==16.6.0
 wcwidth==0.1.7
 web3==5.0.0b2
 websockets==7.0
+Werkzeug==0.15.4
 wheel==0.33.4
 zipp==0.5.1

--- a/merkle_drop/server.py
+++ b/merkle_drop/server.py
@@ -4,6 +4,7 @@ import logging
 
 from flask import Flask
 from flask import jsonify, abort
+from flask_cors import CORS
 from eth_utils import encode_hex, is_checksum_address, to_canonical_address
 import pendulum
 
@@ -23,6 +24,19 @@ def init_gunicorn_logging():
     gunicorn_logger = logging.getLogger("gunicorn.error")
     app.logger.handlers = gunicorn_logger.handlers
     app.logger.setLevel(gunicorn_logger.level)
+
+
+def init_cors(**kwargs):
+    """enable CORS
+
+see https://flask-cors.corydolphin.com/en/latest/api.html#extension
+for allowed kwargs
+
+The default is to allow '*', but one can pass
+e.g. origins='http://example.com' to allow request from one domain
+only."
+"""
+    CORS(app=app, **kwargs)
 
 
 def init(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ eth_utils
 eth-hash[pycryptodome]
 pendulum
 flask
+flask_cors
 
 gunicorn
 pytest

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         "eth_utils",
         "eth-hash[pycryptodome]",
         "flask",
+        "flask_cors",
         "pendulum",
     ],
     entry_points="""


### PR DESCRIPTION
We use flask_cors to implement this. It is optional.