### PR TITLE
[do not merge] Use reorder-python-imports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.6.0
+    hooks:
+    -   id: reorder-python-imports
+
 -   repo: https://github.com/ambv/black
     rev: 19.3b0
     hooks:

--- a/gen-airdrop-list
+++ b/gen-airdrop-list
@@ -1,7 +1,5 @@
 #! /usr/bin/env python3
-
 """generate an airdrop.csv file for testing."""
-
 from eth_account import Account
 
 for num in range(1, 150_000):

--- a/merkle_drop/airdrop.py
+++ b/merkle_drop/airdrop.py
@@ -1,4 +1,5 @@
-from typing import Dict, List
+from typing import Dict
+from typing import List
 
 from .merkle_tree import Item
 

--- a/merkle_drop/cli.py
+++ b/merkle_drop/cli.py
@@ -1,24 +1,28 @@
 import click
-
 import pendulum
-from eth_utils import encode_hex, is_checksum_address, to_canonical_address
-from deploy_tools.cli import (
-    jsonrpc_option,
-    keystore_option,
-    gas_option,
-    gas_price_option,
-    nonce_option,
-    auto_nonce_option,
-    connect_to_json_rpc,
-    retrieve_private_key,
-    get_nonce,
-)
+from deploy_tools.cli import auto_nonce_option
+from deploy_tools.cli import connect_to_json_rpc
+from deploy_tools.cli import gas_option
+from deploy_tools.cli import gas_price_option
+from deploy_tools.cli import get_nonce
+from deploy_tools.cli import jsonrpc_option
+from deploy_tools.cli import keystore_option
+from deploy_tools.cli import nonce_option
+from deploy_tools.cli import retrieve_private_key
 from deploy_tools.deploy import build_transaction_options
+from eth_utils import encode_hex
+from eth_utils import is_checksum_address
+from eth_utils import to_canonical_address
 
-from .airdrop import get_item, to_items, get_balance
+from .airdrop import get_balance
+from .airdrop import get_item
+from .airdrop import to_items
+from .deploy import deploy_merkle_drop
+from .deploy import sum_of_airdropped_tokens
 from .load_csv import load_airdrop_file
-from .merkle_tree import compute_merkle_root, build_tree, create_proof
-from .deploy import deploy_merkle_drop, sum_of_airdropped_tokens
+from .merkle_tree import build_tree
+from .merkle_tree import compute_merkle_root
+from .merkle_tree import create_proof
 
 
 def validate_address(ctx, param, value):

--- a/merkle_drop/deploy.py
+++ b/merkle_drop/deploy.py
@@ -1,7 +1,8 @@
 from typing import Dict
 
+from deploy_tools.deploy import deploy_compiled_contract
+from deploy_tools.deploy import load_contracts_json
 from web3.contract import Contract
-from deploy_tools.deploy import deploy_compiled_contract, load_contracts_json
 
 
 def deploy_merkle_drop(

--- a/merkle_drop/load_csv.py
+++ b/merkle_drop/load_csv.py
@@ -1,7 +1,8 @@
-from typing import Dict
 import csv
+from typing import Dict
 
-from eth_utils import is_checksum_address, to_canonical_address
+from eth_utils import is_checksum_address
+from eth_utils import to_canonical_address
 
 
 def load_airdrop_file(airdrop_file: str) -> Dict[bytes, int]:

--- a/merkle_drop/merkle_tree.py
+++ b/merkle_drop/merkle_tree.py
@@ -1,7 +1,9 @@
-from typing import NamedTuple, Optional
 from typing import List
+from typing import NamedTuple
+from typing import Optional
 
-from eth_utils import keccak, is_canonical_address
+from eth_utils import is_canonical_address
+from eth_utils import keccak
 
 
 class Item(NamedTuple):

--- a/merkle_drop/server.py
+++ b/merkle_drop/server.py
@@ -1,16 +1,22 @@
-import time
-import math
 import logging
+import math
+import time
 
-from flask import Flask
-from flask import jsonify, abort
-from flask_cors import CORS
-from eth_utils import encode_hex, is_checksum_address, to_canonical_address
 import pendulum
+from eth_utils import encode_hex
+from eth_utils import is_checksum_address
+from eth_utils import to_canonical_address
+from flask import abort
+from flask import Flask
+from flask import jsonify
+from flask_cors import CORS
 
-from merkle_drop.airdrop import get_item, get_balance, to_items
+from merkle_drop.airdrop import get_balance
+from merkle_drop.airdrop import get_item
+from merkle_drop.airdrop import to_items
 from merkle_drop.load_csv import load_airdrop_file
-from merkle_drop.merkle_tree import create_proof, build_tree
+from merkle_drop.merkle_tree import build_tree
+from merkle_drop.merkle_tree import create_proof
 
 app = Flask("Merkle Airdrop Backend Server")
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name="merkle-drop",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
-import pytest
 import eth_tester
+import pytest
 
-from merkle_drop.merkle_tree import build_tree, Item, create_proof, validate_proof
+from merkle_drop.merkle_tree import build_tree
+from merkle_drop.merkle_tree import create_proof
+from merkle_drop.merkle_tree import Item
+from merkle_drop.merkle_tree import validate_proof
 
 # increase eth_tester's GAS_LIMIT
 assert eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT < 8 * 10 ** 6

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
 import pytest
 from click.testing import CliRunner
+from eth_utils import is_hex
+from eth_utils import to_checksum_address
+from eth_utils import to_normalized_address
 
-from eth_utils import to_checksum_address, to_normalized_address, is_hex
-
-from merkle_drop.load_csv import load_airdrop_file, validate_address_value_pairs
 from merkle_drop.cli import main
+from merkle_drop.load_csv import load_airdrop_file
+from merkle_drop.load_csv import validate_address_value_pairs
 
 
 A_ADDRESS = b"\xaa" * 20

--- a/tests/test_merkle_drop.py
+++ b/tests/test_merkle_drop.py
@@ -1,6 +1,5 @@
-import pytest
-
 import eth_tester.exceptions
+import pytest
 from eth_utils import to_checksum_address
 from web3.exceptions import BadFunctionCallOutput
 

--- a/tests/test_merkle_tree.py
+++ b/tests/test_merkle_tree.py
@@ -1,17 +1,14 @@
 import pytest
-
 from eth_utils import keccak
 
-from merkle_drop.merkle_tree import (
-    build_tree,
-    in_tree,
-    create_proof,
-    validate_proof,
-    compute_parent_hash,
-    compute_leaf_hash,
-    compute_merkle_root,
-    Item,
-)
+from merkle_drop.merkle_tree import build_tree
+from merkle_drop.merkle_tree import compute_leaf_hash
+from merkle_drop.merkle_tree import compute_merkle_root
+from merkle_drop.merkle_tree import compute_parent_hash
+from merkle_drop.merkle_tree import create_proof
+from merkle_drop.merkle_tree import in_tree
+from merkle_drop.merkle_tree import Item
+from merkle_drop.merkle_tree import validate_proof
 
 
 @pytest.fixture


### PR DESCRIPTION
I'd like to collect feedback if we should use this.

Use reorder-python-imports pre-commit hook

This sorts and groups imports.

One thing it does may be controversial. It splits 'from imports', e.g.

    from os.path import abspath, exists

becomes

    from os.path import abspath
    from os.path import exists

It does this because it tries to minimize merge conflicts.

Another alternative to sorting imports is isort, which the raiden
project is using.

isort didn't work out of the box, because it formats files not
compatible with black's formatting.

Visit https://github.com/asottile/reorder_python_imports#what-does-it-do
for more information.
