### PR TITLE
Use less strict address check in ReST Interface

### DIFF
--- a/merkle_drop/server.py
+++ b/merkle_drop/server.py
@@ -5,7 +5,7 @@ import logging
 from flask import Flask
 from flask import jsonify, abort
 from flask_cors import CORS
-from eth_utils import encode_hex, is_address, to_canonical_address
+from eth_utils import encode_hex, is_address, to_canonical_address, to_checksum_address
 import pendulum
 
 from merkle_drop.airdrop import get_item, get_balance, to_items
@@ -92,7 +92,7 @@ def get_entitlement_for(address):
         decayed_tokens = decay_tokens(eligible_tokens)
     return jsonify(
         {
-            "address": address,
+            "address": to_checksum_address(address),
             "originalTokenBalance": eligible_tokens,
             "currentTokenBalance": decayed_tokens,
             "proof": [encode_hex(hash_) for hash_ in proof],

--- a/merkle_drop/server.py
+++ b/merkle_drop/server.py
@@ -5,7 +5,7 @@ import logging
 from flask import Flask
 from flask import jsonify, abort
 from flask_cors import CORS
-from eth_utils import encode_hex, is_checksum_address, to_canonical_address
+from eth_utils import encode_hex, is_address, to_canonical_address
 import pendulum
 
 from merkle_drop.airdrop import get_item, get_balance, to_items
@@ -79,7 +79,7 @@ def internal_server_error(e):
 
 @app.route("/entitlement/<string:address>", methods=["GET"])
 def get_entitlement_for(address):
-    if not is_checksum_address(address):
+    if not is_address(address):
         abort(400, "The address is not in checksum-case or invalid")
     canonical_address = to_canonical_address(address)
 


### PR DESCRIPTION
Use is_address to also allow not checksum addresses and addresses
without 0x. It will still check the checksum if mixed cased is used.