### PR TITLE
Upgrade builder image to master27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ templates:
 executors:
   ubuntu-builder:
     docker:
-      - image: trustlines/builder:master26
+      - image: trustlines/builder:master27
         environment:
           - SOLC_VERSION=v0.5.8
     working_directory: ~/repo


### PR DESCRIPTION
This fixes the issue with twine not being able to upload a wheel to
PyPI. We've ran into the following problem previously:

,----
| twine upload dist/*
|
| Uploading distributions to https://upload.pypi.org/legacy/
| TypeError: expected string or bytes-like object
`----